### PR TITLE
Add pick coins method for []Coin

### DIFF
--- a/types/coin.go
+++ b/types/coin.go
@@ -3,6 +3,15 @@ package types
 import (
 	"errors"
 	"math/big"
+	"sort"
+)
+
+var ErrCoinsNotMatchRequest error
+
+const (
+	PickSmaller = iota // pick smaller coins to match amount
+	PickBigger         // pick bigger coins to match amount
+	PickByOrder        // pick coins by coins order to match amount
 )
 
 type Coin struct {
@@ -14,6 +23,10 @@ type Coin struct {
 }
 
 type Coins []Coin
+
+func init() {
+	ErrCoinsNotMatchRequest = errors.New("coins not match request")
+}
 
 func (cs Coins) TotalBalance() *big.Int {
 	total := big.NewInt(0)
@@ -30,4 +43,75 @@ func (cs Coins) PickCoinNoLess(amount uint64) (*Coin, error) {
 		}
 	}
 	return nil, errors.New("No coin is enough to cover the gas.")
+}
+
+// PickSUICoinsWithGas pick coins, which sum >= amount, and pick a gas coin >= gasAmount which not in coins
+// if not satisfated, an
+// if gasAmount == 0, a nil gasCoin will return
+// pickMethod, see PickSmaller|PickBigger|PickByOrder
+func (cs Coins) PickSUICoinsWithGas(amount uint64, gasAmount uint64, pickMethod int) (Coins, *Coin, error) {
+	if gasAmount == 0 {
+		res, err := cs.PickCoins(amount, pickMethod)
+		return res, nil, err
+	}
+
+	if amount+gasAmount == 0 {
+		return make(Coins, 0), nil, nil
+	} else if len(cs) == 0 {
+		return cs, nil, ErrCoinsNotMatchRequest
+	}
+
+	// find smallest to match gasAmount
+	var gasCoin *Coin
+	var selectIndex int
+	for i := range cs {
+		if cs[i].Balance < gasAmount {
+			continue
+		}
+
+		if nil == gasCoin || gasCoin.Balance > cs[i].Balance {
+			gasCoin = &cs[i]
+			selectIndex = i
+		}
+	}
+	if nil == gasCoin {
+		return nil, nil, ErrCoinsNotMatchRequest
+	}
+
+	lastCoins := make(Coins, 0, len(cs)-1)
+	lastCoins = append(lastCoins, cs[0:selectIndex]...)
+	lastCoins = append(lastCoins, cs[selectIndex+1:]...)
+	pickCoins, err := lastCoins.PickCoins(amount, pickMethod)
+	return pickCoins, gasCoin, err
+}
+
+// PickCoins pick coins, which sum >= amount,
+// pickMethod, see PickSmaller|PickBigger|PickByOrder
+func (cs Coins) PickCoins(amount uint64, pickMethod int) (Coins, error) {
+	var sortedCoins Coins
+	if pickMethod == PickByOrder {
+		sortedCoins = cs
+	} else {
+		sortedCoins = make(Coins, len(cs))
+		copy(sortedCoins, cs)
+		sort.Slice(sortedCoins, func(i, j int) bool {
+			if pickMethod == PickSmaller {
+				return sortedCoins[i].Balance < sortedCoins[j].Balance
+			} else {
+				return sortedCoins[i].Balance >= sortedCoins[j].Balance
+			}
+		})
+	}
+
+	result := make(Coins, 0)
+	var total uint64
+	for _, coin := range sortedCoins {
+		result = append(result, coin)
+		total += coin.Balance
+		if total >= amount {
+			return result, nil
+		}
+	}
+
+	return nil, ErrCoinsNotMatchRequest
 }

--- a/types/coin.go
+++ b/types/coin.go
@@ -46,7 +46,7 @@ func (cs Coins) PickCoinNoLess(amount uint64) (*Coin, error) {
 }
 
 // PickSUICoinsWithGas pick coins, which sum >= amount, and pick a gas coin >= gasAmount which not in coins
-// if not satisfated, an
+// if not satisfated amount/gasAmount, an ErrCoinsNotMatchRequest error will return
 // if gasAmount == 0, a nil gasCoin will return
 // pickMethod, see PickSmaller|PickBigger|PickByOrder
 func (cs Coins) PickSUICoinsWithGas(amount uint64, gasAmount uint64, pickMethod int) (Coins, *Coin, error) {
@@ -87,6 +87,7 @@ func (cs Coins) PickSUICoinsWithGas(amount uint64, gasAmount uint64, pickMethod 
 
 // PickCoins pick coins, which sum >= amount,
 // pickMethod, see PickSmaller|PickBigger|PickByOrder
+// // if not satisfated amount, an ErrCoinsNotMatchRequest error will return
 func (cs Coins) PickCoins(amount uint64, pickMethod int) (Coins, error) {
 	var sortedCoins Coins
 	if pickMethod == PickByOrder {

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -1,0 +1,248 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCoins_PickSUICoinsWithGas(t *testing.T) {
+	// coins 1,2,3,4,5
+	testCoins := Coins{
+		{
+			Balance: 3,
+		},
+		{
+			Balance: 5,
+		},
+		{
+			Balance: 1,
+		},
+		{
+			Balance: 4,
+		},
+		{
+			Balance: 2,
+		},
+	}
+	type args struct {
+		amount     uint64
+		gasAmount  uint64
+		pickMethod int
+	}
+	tests := []struct {
+		name    string
+		cs      Coins
+		args    args
+		want    Coins
+		want1   *Coin
+		wantErr bool
+	}{
+		{
+			name: "case success 1",
+			cs:   testCoins,
+			args: args{
+				amount:     0,
+				gasAmount:  0,
+				pickMethod: PickSmaller,
+			},
+			want:    nil,
+			want1:   nil,
+			wantErr: false,
+		},
+		{
+			name: "case success 2",
+			cs:   testCoins,
+			args: args{
+				amount:     1,
+				gasAmount:  2,
+				pickMethod: PickSmaller,
+			},
+			want:    Coins{{Balance: 1}},
+			want1:   &Coin{Balance: 2},
+			wantErr: false,
+		},
+		{
+			name: "case success 3",
+			cs:   testCoins,
+			args: args{
+				amount:     4,
+				gasAmount:  2,
+				pickMethod: PickSmaller,
+			},
+			want:    Coins{{Balance: 1}, {Balance: 3}},
+			want1:   &Coin{Balance: 2},
+			wantErr: false,
+		},
+		{
+			name: "case success 4",
+			cs:   testCoins,
+			args: args{
+				amount:     6,
+				gasAmount:  2,
+				pickMethod: PickSmaller,
+			},
+			want:    Coins{{Balance: 1}, {Balance: 3}, {Balance: 4}},
+			want1:   &Coin{Balance: 2},
+			wantErr: false,
+		},
+		{
+			name: "case error 1",
+			cs:   testCoins,
+			args: args{
+				amount:     6,
+				gasAmount:  6,
+				pickMethod: PickSmaller,
+			},
+			want:    Coins{},
+			want1:   nil,
+			wantErr: true,
+		},
+		{
+			name: "case error 1",
+			cs:   testCoins,
+			args: args{
+				amount:     100,
+				gasAmount:  3,
+				pickMethod: PickSmaller,
+			},
+			want:    Coins{},
+			want1:   &Coin{Balance: 3},
+			wantErr: true,
+		},
+		{
+			name: "case bigger 1",
+			cs:   testCoins,
+			args: args{
+				amount:     3,
+				gasAmount:  3,
+				pickMethod: PickBigger,
+			},
+			want:    Coins{{Balance: 5}},
+			want1:   &Coin{Balance: 3},
+			wantErr: false,
+		},
+		{
+			name: "case order 1",
+			cs:   testCoins,
+			args: args{
+				amount:     3,
+				gasAmount:  3,
+				pickMethod: PickByOrder,
+			},
+			want:    Coins{{Balance: 5}},
+			want1:   &Coin{Balance: 3},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := tt.cs.PickSUICoinsWithGas(tt.args.amount, tt.args.gasAmount, tt.args.pickMethod)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Coins.PickSUICoinsWithGas() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(got) != 0 && len(tt.want) != 0 {
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("Coins.PickSUICoinsWithGas() got = %v, want %v", got, tt.want)
+				}
+			}
+			if !reflect.DeepEqual(got1, tt.want1) {
+				t.Errorf("Coins.PickSUICoinsWithGas() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func TestCoins_PickCoins(t *testing.T) {
+	// coins 1,2,3,4,5
+	testCoins := Coins{
+		{
+			Balance: 3,
+		},
+		{
+			Balance: 5,
+		},
+		{
+			Balance: 1,
+		},
+		{
+			Balance: 4,
+		},
+		{
+			Balance: 2,
+		},
+	}
+	type args struct {
+		amount     uint64
+		pickMethod int
+	}
+	tests := []struct {
+		name    string
+		cs      Coins
+		args    args
+		want    Coins
+		wantErr bool
+	}{
+		{
+			name:    "smaller 1",
+			cs:      testCoins,
+			args:    args{amount: 2, pickMethod: PickSmaller},
+			want:    Coins{{Balance: 1}, {Balance: 2}},
+			wantErr: false,
+		},
+		{
+			name:    "smaller 2",
+			cs:      testCoins,
+			args:    args{amount: 4, pickMethod: PickSmaller},
+			want:    Coins{{Balance: 1}, {Balance: 2}, {Balance: 3}},
+			wantErr: false,
+		},
+		{
+			name:    "bigger 1",
+			cs:      testCoins,
+			args:    args{amount: 2, pickMethod: PickBigger},
+			want:    Coins{{Balance: 5}},
+			wantErr: false,
+		},
+		{
+			name:    "bigger 2",
+			cs:      testCoins,
+			args:    args{amount: 6, pickMethod: PickBigger},
+			want:    Coins{{Balance: 5}, {Balance: 4}},
+			wantErr: false,
+		},
+		{
+			name:    "pick by order 1",
+			cs:      testCoins,
+			args:    args{amount: 6, pickMethod: PickByOrder},
+			want:    Coins{{Balance: 3}, {Balance: 5}},
+			wantErr: false,
+		},
+		{
+			name:    "pick by order 2",
+			cs:      testCoins,
+			args:    args{amount: 15, pickMethod: PickByOrder},
+			want:    testCoins,
+			wantErr: false,
+		},
+		{
+			name:    "pick error",
+			cs:      testCoins,
+			args:    args{amount: 16, pickMethod: PickByOrder},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.cs.PickCoins(tt.args.amount, tt.args.pickMethod)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Coins.PickCoins() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Coins.PickCoins() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add methods on Coins type:
- `PickSUICoinsWithGas` pick SUI coins and a gas coin to match amount/gasAmount request
- `PickCoins` pick coins to match amount request

`pickMethod` support:
- `PickSmaller` pick smaller coins to match amount
- `PickBigger` pick bigger coins to match amount
- `PickByOrder` pick coins by coins order to match amount