### PR TITLE
feat(types/types): add Pay/PaySui/PayAllSui transaction kind

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -134,6 +134,20 @@ type TransferSui struct {
 	Recipient Address `json:"recipient"`
 	Amount    uint64  `json:"amount"`
 }
+type Pay struct {
+	Coins      []ObjectRef `json:"coins"`
+	Recipients []Address   `json:"recipients"`
+	Amounts    []uint64    `json:"amounts"`
+}
+type PaySui struct {
+	Coins      []ObjectRef `json:"coins"`
+	Recipients []Address   `json:"recipients"`
+	Amounts    []uint64    `json:"amounts"`
+}
+type PayAllSui struct {
+	Coins     []ObjectRef `json:"coins"`
+	Recipient Address     `json:"recipient"`
+}
 type ChangeEpoch struct {
 	Epoch             interface{} `json:"epoch"`
 	StorageCharge     uint64      `json:"storage_charge"`
@@ -146,6 +160,9 @@ type SingleTransactionKind struct {
 	Call           *MoveCall       `json:"Call,omitempty"`
 	TransferSui    *TransferSui    `json:"TransferSui,omitempty"`
 	ChangeEpoch    *ChangeEpoch    `json:"ChangeEpoch,omitempty"`
+	PaySui         *PaySui         `json:"PaySui,omitempty"`
+	Pay            *Pay            `json:"Pay,omitempty"`
+	PayAllSui      *PayAllSui      `json:"PayAllSui,omitempty"`
 }
 
 type SenderSignedData struct {


### PR DESCRIPTION
Hi,

We (at [sentio.xyz](https://www.sentio.xyz/)) are trying to build a go application for sui.  Found that a few transaction types are missing, resulting in responses not being deserialized properly.

I am submitting a PR to add these transaction kinds (according to source code: 
https://github.com/MystenLabs/sui/blob/testnet/sdk/typescript/src/types/transactions.ts#L83):
- Pay
- PaySui
- PayAllSui

Please let me know if any other changes are needed.

Go is our primary programming language, and we intend to build things around sui in the next step.
That means we are also interested in contributing more on this sdk.

Thank you!