### PR TITLE
fix(lib/serialization): remove the custom `MarshalBCS` function for B…

### DIFF
--- a/lib/serialization.go
+++ b/lib/serialization.go
@@ -107,10 +107,6 @@ func (h *Base64Data) UnmarshalJSON(data []byte) error {
 	return err
 }
 
-func (h Base64Data) MarshalBCS() ([]byte, error) {
-	return h, nil
-}
-
 type Base58 []byte
 
 func NewBase58(str string) (*Base58, error) {


### PR DESCRIPTION
…ase64Data

The `SuiAddress` has special type, we should recover the `Base64Data`'s `MarshalBCS` as default

fix #27