### PR TITLE
chore: allow providing password in account creation

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -45,7 +45,11 @@ func NewAccountWithKeystore(keystore string) (*Account, error) {
 }
 
 func NewAccountWithMnemonic(mnemonic string) (*Account, error) {
-	seed, err := bip39.NewSeedWithErrorChecking(mnemonic, "")
+	return NewAccountWithMnemonicAndPassword(mnemonic, "")
+}
+
+func NewAccountWithMnemonicAndPassword(mnemonic string, password string) (*Account, error) {
+	seed, err := bip39.NewSeedWithErrorChecking(mnemonic, password)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allow providing a password alongside the mnemonic when creating new accounts. There are no breaking changes, as `NewAccountWithMnemonic(mnemonic string)` can still be called as before.