### PR TITLE
Add coin response type given sui rpc update

### DIFF
--- a/types/coin.go
+++ b/types/coin.go
@@ -2,9 +2,10 @@ package types
 
 import (
 	"errors"
-	"github.com/coming-chat/go-sui/v2/sui_types"
 	"math/big"
 	"sort"
+
+	"github.com/coming-chat/go-sui/v2/sui_types"
 )
 
 const SUI_COIN_TYPE = "0x2::sui::SUI"
@@ -36,7 +37,7 @@ func (c *Coin) Reference() *sui_types.ObjectRef {
 	}
 }
 
-type CoinPage = Page[Coin, sui_types.ObjectID]
+type CoinPage = Page[Coin, string]
 
 func (c *Coin) IsSUI() bool {
 	return c.CoinType == SUI_COIN_TYPE

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 type suiAddress = sui_types.SuiAddress
-type suiObjectID = sui_types.ObjectID
 
 func balanceObject(val uint64) SafeSuiBigInt[uint64] {
 	return NewSafeSuiBigInt(val)
@@ -263,7 +262,7 @@ func TestPickupCoins(t *testing.T) {
 		{
 			name: "moreCount = 3",
 			args: args{
-				inputCoins: &Page[Coin, suiObjectID]{
+				inputCoins: &Page[Coin, string]{
 					Data: []Coin{
 						coin(1e3), coin(1e5), coin(1e2), coin(1e4),
 					},
@@ -282,7 +281,7 @@ func TestPickupCoins(t *testing.T) {
 		{
 			name: "large gas",
 			args: args{
-				inputCoins: &Page[Coin, suiObjectID]{
+				inputCoins: &Page[Coin, string]{
 					Data: []Coin{
 						coin(1e3), coin(1e5), coin(1e2), coin(1e4),
 					},
@@ -302,7 +301,7 @@ func TestPickupCoins(t *testing.T) {
 		{
 			name: "ErrNoCoinsFound",
 			args: args{
-				inputCoins: &Page[Coin, suiObjectID]{
+				inputCoins: &Page[Coin, string]{
 					Data: []Coin{},
 				},
 				targetAmount: *big.NewInt(101000),
@@ -312,7 +311,7 @@ func TestPickupCoins(t *testing.T) {
 		{
 			name: "ErrInsufficientBalance",
 			args: args{
-				inputCoins: &Page[Coin, suiObjectID]{
+				inputCoins: &Page[Coin, string]{
 					Data: []Coin{
 						coin(1e5), coin(1e6), coin(1e4),
 					},
@@ -324,7 +323,7 @@ func TestPickupCoins(t *testing.T) {
 		{
 			name: "ErrNeedMergeCoin 1",
 			args: args{
-				inputCoins: &Page[Coin, suiObjectID]{
+				inputCoins: &Page[Coin, string]{
 					Data: []Coin{
 						coin(1e5), coin(1e6), coin(1e4),
 					},
@@ -337,7 +336,7 @@ func TestPickupCoins(t *testing.T) {
 		{
 			name: "ErrNeedMergeCoin 2",
 			args: args{
-				inputCoins: &Page[Coin, suiObjectID]{
+				inputCoins: &Page[Coin, string]{
 					Data: []Coin{
 						coin(1e5), coin(1e6), coin(1e4), coin(1e5),
 					},

--- a/types/common.go
+++ b/types/common.go
@@ -2,9 +2,10 @@ package types
 
 import (
 	"fmt"
+	"math/big"
+
 	"github.com/coming-chat/go-sui/v2/sui_types"
 	"github.com/shopspring/decimal"
-	"math/big"
 )
 
 type SuiBigInt = decimal.Decimal
@@ -83,7 +84,7 @@ type ObjectOwner struct {
 }
 
 type Page[T SuiTransactionBlockResponse | SuiEvent | Coin | SuiObjectResponse | DynamicFieldInfo | string,
-	C sui_types.TransactionDigest | EventId | sui_types.ObjectID] struct {
+	C sui_types.TransactionDigest | EventId | sui_types.ObjectID | string] struct {
 	Data        []T  `json:"data"`
 	NextCursor  *C   `json:"nextCursor,omitempty"`
 	HasNextPage bool `json:"hasNextPage"`


### PR DESCRIPTION
With https://github.com/MystenLabs/sui/pull/21137, the coin response type uses string instead of object id for cursor.

Hence, we need to update the page type to reflect that, else the client would run into unexpected bytes error.

Test: I updated existing test, also tested the patch with our go client.